### PR TITLE
Fix model reference in YAML configuration

### DIFF
--- a/examples/embodiment/config/libero_spatial_nft_actor_openpi_pi05.yaml
+++ b/examples/embodiment/config/libero_spatial_nft_actor_openpi_pi05.yaml
@@ -1,7 +1,7 @@
 defaults:
   - env/libero_spatial@env.train
   - env/libero_spatial@env.eval
-  - model/pi05@actor.model
+  - model/pi0_5@actor.model
   - training_backend/fsdp@actor.fsdp_config
   - override hydra/job_logging: stdout
 


### PR DESCRIPTION
This PR fixes broken Hydra config references in the `*_pi05` embodiment presets.

  libero_spatial_nft_actor_openpi_pi05 was referencing:

  ```yaml
  - model/pi05@actor.model

  but the actual model config file in the repo is:

  examples/embodiment/config/model/pi0_5.yaml

  Because of this mismatch, running the corresponding embodiment script fails during Hydra config composition with:

  In 'libero_spatial_nft_actor_openpi_pi05': Could not load 'model/pi05'.

  ## Reproduction

  Run:

  bash examples/embodiment/distributed.sh

  Observed error:

  In 'libero_spatial_nft_actor_openpi_pi05': Could not load 'model/pi05'.


  ## Fix

  Updated the following config files to use:

  - model/pi0_5@actor.model

  Files changed:

  - examples/embodiment/config/libero_spatial_nft_actor_openpi_pi05.yaml